### PR TITLE
fix: updated the cloned luajit branch to OpenResty's.

### DIFF
--- a/opsboy
+++ b/opsboy
@@ -306,7 +306,9 @@ sub make ($$) {
             my $dir = shift @args;
             my $branch = shift @args;
 
-            if (!defined $branch) {
+            if (defined $branch) {
+                $branch =~ s/\$([a-zA-Z]\w*)/$ENV{$1}/g;
+            } else {
                 $branch = 'master';
             }
 

--- a/samples/ortest-ec2.ob
+++ b/samples/ortest-ec2.ob
@@ -98,7 +98,7 @@ luajit {
 }
 
 luajit-git {
-    git git://github.com/openresty/luajit2.git ~/git/luajit2;
+    git git://github.com/openresty/luajit2.git ~/git/luajit2 $luajit_branch;
 }
 
 

--- a/samples/ortest-ec2.ob.tt
+++ b/samples/ortest-ec2.ob.tt
@@ -208,7 +208,7 @@ luajit {
 }
 
 luajit-git {
-    git git://github.com/openresty/luajit2.git ~/git/luajit2;
+    git git://github.com/openresty/luajit2.git ~/git/luajit2 $luajit_branch;
 }
 
 [% BLOCK build_lua_lib %]


### PR DESCRIPTION
Currently, openresty-tester.pl experiences the following error on EC2
test nodes:

    making luajit-git ...
    git clone -b master git://github.com/openresty/luajit2.git /root/git/luajit2
    Cloning into '/root/git/luajit2'...
    fatal: Remote branch master not found in upstream origin

The master branch is indeed gone from the openresty/luajit2 repository.