### PR TITLE
bugfix: make memcached explicitly listening on port 11211 of udp.

### DIFF
--- a/samples/ortest-ec2.ob
+++ b/samples/ortest-ec2.ob
@@ -1072,8 +1072,8 @@ mysql {
 }
 
 run-memcached {
-    running 'memcached -d -p 11211';
-    sh 'memcached -d -p 11211 -l 127.0.0.1';
+    running 'memcached -d -p 11211 -U 11211';
+    sh 'memcached -d -p 11211 -U 11211 -l 127.0.0.1';
     dep memcached;
 }
 

--- a/samples/ortest-ec2.ob.tt
+++ b/samples/ortest-ec2.ob.tt
@@ -835,8 +835,8 @@ mysql {
 }
 
 run-memcached {
-    running 'memcached -d -p 11211';
-    sh 'memcached -d -p 11211 -l 127.0.0.1';
+    running 'memcached -d -p 11211 -U 11211';
+    sh 'memcached -d -p 11211 -U 11211 -l 127.0.0.1';
     dep memcached;
 }
 


### PR DESCRIPTION
Currently memcached no longer listens on udp ports by default, you need to use `-U` to explicitly specify a port to listen on.