### PR TITLE
ortest-ec2: upgraded dependencies version for ec2.

### DIFF
--- a/samples/ortest-ec2.ob
+++ b/samples/ortest-ec2.ob
@@ -2,8 +2,8 @@
 
 jobs = 3;
 ngx_redis_version = 0.3.7;
-nginx_version = 1.19.3;
-openresty_version = 1.17.8.2;
+nginx_version = 1.19.9;
+openresty_version = 1.19.3.1;
 redis_version = 5.0.9;
 ngx_auth_request_version = 0.2;
 pcre_version = 8.44;
@@ -16,7 +16,7 @@ perl516_version = 5.16.2;
 bison_version = 3.7.3;
 ccache_version = 3.7.12;
 luajit_branch = v2.1-agentzh;
-openssl_version = 1.1.1h;
+openssl_version = 1.1.1k;
 openssl_patch_version = 1.1.1f;
 #luajit_branch = v2.1-agentzh-no-stitch;
 use_lua_resty_core = 0;

--- a/samples/ortest-ec2.ob.tt
+++ b/samples/ortest-ec2.ob.tt
@@ -2,7 +2,7 @@
 
 jobs = 3;
 ngx_redis_version = 0.3.7;
-nginx_version = 1.19.3;
+nginx_version = 1.19.9;
 openresty_version = 1.19.3.1;
 redis_version = 5.0.9;
 ngx_auth_request_version = 0.2;
@@ -16,7 +16,7 @@ perl516_version = 5.16.2;
 bison_version = 3.7.3;
 ccache_version = 3.7.12;
 luajit_branch = v2.1-agentzh;
-openssl_version = 1.1.1h;
+openssl_version = 1.1.1k;
 openssl_patch_version = 1.1.1f;
 #luajit_branch = v2.1-agentzh-no-stitch;
 use_lua_resty_core = 0;


### PR DESCRIPTION
* upgraded nginx_version to 1.19.9.
* upgraded openssl_version to 1.1.1k.