### PR TITLE
ortest: updated whitelist for ngx_stream_lua t/154-semaphore.t.

### DIFF
--- a/misc/logs/parse-logs
+++ b/misc/logs/parse-logs
@@ -579,6 +579,7 @@ my %white_list = (
         ['h', '068-socket-keepalive.t', qr/pattern ".*?" should not match any line in error\.log/],
         ['h', '068-socket-keepalive.t', qr/pattern ".*?" should match a line in error\.log/],
         ['h', '068-socket-keepalive.t', 'TEST 18: custom pools (same pool for the same path) - unix - response_body - response is expected'],
+        ['w', '154-semaphore.t', 'TEST 3: exit before post_handler was called - grep_error_log_out'],
     ],
 
     ngx_lua => [


### PR DESCRIPTION
MOCKEAGAIN 'w' mode, in which the stream connection is closed later than the semaphore event handler.

```
#   Failed test 't/154-semaphore.t TEST 3: exit before post_handler was called - grep_error_log_out (req 1)'
#   at /home/jiahao/work/org/stream-lua-nginx-module/../test-nginx/lib/Test/Nginx/Socket.pm line 1223.
# @@ -1,5 +1,5 @@
#  ngx.sem wait start,
#  ngx.sem post start,
#  ngx.sem post end,
# -close stream connection
#  semaphore handler: wait queue: empty, resource count: 1
# +close stream connection
```