### PR TITLE
ortest: updated whitelist for ngx_stream_lua t/160.t and t/162.t.

### DIFF
--- a/misc/logs/parse-logs
+++ b/misc/logs/parse-logs
@@ -579,6 +579,9 @@ my %white_list = (
         ['h', '068-socket-keepalive.t', qr/pattern ".*?" should not match any line in error\.log/],
         ['h', '068-socket-keepalive.t', qr/pattern ".*?" should match a line in error\.log/],
         ['h', '068-socket-keepalive.t', 'TEST 18: custom pools (same pool for the same path) - unix - response_body - response is expected'],
+        ['r', '160-disable-init-by-lua.t', qr/TEST 1: .*? - pattern "failed \(2: No such file or directory\)" should match a line in error\.log/],
+        ['h', '160-disable-init-by-lua.t', qr/TEST 1: .*? - pattern "failed \(2: No such file or directory\)" should match a line in error\.log/],
+        ['h', '162-ssl-client-hello-by.t', qr/pattern "\[error\]" should not match any line in error\.log but matches line .*? send\(\) failed \(111: Connection refused\) while logging to syslog/],
     ],
 
     ngx_lua => [


### PR DESCRIPTION
reason for whitelisting: in hup reload mode, logs from other use cases can
pollute the current use case